### PR TITLE
Feature: grab message logo from guild logo, fallback to default if none is set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /gregbot
 # Keep this before copying source in order to keep compilation times sane and take advantage of image caching
 ADD Pipfile .
 ADD Pipfile.lock .
-RUN apk add gcc libxml2-dev libxslt-dev musl-dev openssl-dev libffi-dev libjpeg-turbo-dev libwebp rust cargo git
+RUN apk add gcc libxml2-dev libxslt-dev musl-dev openssl-dev libffi-dev libjpeg-turbo-dev libwebp libwebp-dev rust cargo git
 RUN python -m pip install pipenv
 RUN pipenv install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /gregbot
 # Keep this before copying source in order to keep compilation times sane and take advantage of image caching
 ADD Pipfile .
 ADD Pipfile.lock .
-RUN apk add gcc libxml2-dev libxslt-dev musl-dev openssl-dev libffi-dev libjpeg-turbo-dev rust cargo git
+RUN apk add gcc libxml2-dev libxslt-dev musl-dev openssl-dev libffi-dev libjpeg-turbo-dev libwebp rust cargo git
 RUN python -m pip install pipenv
 RUN pipenv install
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,8 +1,8 @@
 pings:
+  default_icon_url: "https://pm1.narvii.com/6422/439159c580614aa8b9e801f87f6ffca3c5f454d0_128.jpg"
   discord_relays:
     - token: "YOUR_TOKEN_HERE"
       description: "Description"
-      logo_url: "https://pm1.narvii.com/6422/439159c580614aa8b9e801f87f6ffca3c5f454d0_128.jpg"
       routes:
         - from_channels:
             - 1

--- a/ext/pings/aggregator.py
+++ b/ext/pings/aggregator.py
@@ -32,6 +32,7 @@ class PingAggregator(commands.Cog, name='PingAggregator'):
             self.relays.append(
                 JabberRelay(self.bot, jabber_config, self.logger))
         for discord_config in config.get("discord_relays", []):
+            discord_config['default_icon_url'] = config['default_icon_url']
             self.relays.append(DiscordRelay(self.bot, discord_config))
 
     async def on_broadcast(self, package):

--- a/ext/pings/discordrelay.py
+++ b/ext/pings/discordrelay.py
@@ -37,6 +37,7 @@ class DiscordRelay(commands.Cog, name='DiscordRelay'):
         '''
         if message.guild is not None:
             icon_asset = message.guild.icon_url
+            self.logger.debug('Guild {} asset {} is_animated {}'.format(message.guild.id, str(icon_asset), message.guild.is_icon_animated()))
             if icon_asset is not None and not message.guild.is_icon_animated():
                 return str(icon_asset)
 

--- a/ext/pings/discordrelay.py
+++ b/ext/pings/discordrelay.py
@@ -13,10 +13,10 @@ class DiscordRelay(commands.Cog, name='DiscordRelay'):
         self.logger = get_logger(__name__)
         self.bot = bot
         self.config = config
-        self.config["embed_colour"] = get_embed_colour(self.config["logo_url"])
         self.client = Client(loop=bot.loop)
         self.client.event(self.on_ready)
         self.client.event(self.on_message)
+        self._embed_colour_cache = {}
         bot.loop.create_task(self.client.start(config["token"]))
 
     def disconnect(self):
@@ -30,6 +30,28 @@ class DiscordRelay(commands.Cog, name='DiscordRelay'):
             state['guilds'] = self.client.guilds
 
         return state
+
+    def get_message_logo(self, message):
+        '''
+        Extracts message logo url from the guild logo. Falls back to the default logo otherwise.
+        '''
+        if message.guild is not None:
+            icon_asset = message.guild.icon_url
+            if icon_asset is not None and not message.guild.is_icon_animated():
+                return str(icon_asset)
+
+        return self.config['default_icon_url']
+
+    def get_cached_embed_colour(self, url):
+        '''
+        Stores colourthief output locally for reuse
+        '''
+        if url in self._embed_colour_cache:
+            return self._embed_colour_cache[url]
+
+        colour = get_embed_colour(url)
+        self._embed_colour_cache[url] = colour
+        return colour
 
     def route_message(self, message):
         '''
@@ -64,6 +86,7 @@ class DiscordRelay(commands.Cog, name='DiscordRelay'):
 
     async def on_message(self, message):
         if message.mention_everyone:
+            message_logo = self.get_message_logo(message)
             package = {
                 'body': message.clean_content,
                 'sender': message.author.display_name,
@@ -72,7 +95,7 @@ class DiscordRelay(commands.Cog, name='DiscordRelay'):
                     message.guild.name,
                     message.channel.name or "Private Channel"
                 ),
-                'logo_url': self.config['logo_url'],
-                'embed_colour': self.config["embed_colour"]
+                'logo_url': message_logo,
+                'embed_colour': self.get_cached_embed_colour(message_logo)
             }
             self.bot.dispatch('broadcast', package)

--- a/ext/pings/discordrelay.py
+++ b/ext/pings/discordrelay.py
@@ -38,7 +38,7 @@ class DiscordRelay(commands.Cog, name='DiscordRelay'):
         if message.guild is not None:
             icon_asset = message.guild.icon_url
             self.logger.debug('Guild {} asset {} is_animated {}'.format(message.guild.id, str(icon_asset), message.guild.is_icon_animated()))
-            if icon_asset is not None and not message.guild.is_icon_animated():
+            if icon_asset is not None:
                 return str(icon_asset)
 
         return self.config['default_icon_url']

--- a/utils/colourthief.py
+++ b/utils/colourthief.py
@@ -1,4 +1,6 @@
-from urllib.request import urlopen
+from io import BytesIO
+
+import requests
 
 from colorthief import ColorThief as ColourThief
 from colorthief import MMCQ
@@ -7,7 +9,7 @@ from discord import Colour
 
 def get_embed_colour(url):
     colour_thief = SaturatedColourThief(
-        urlopen(url)
+        BytesIO(requests.get(url).content)
     )
     return colour_thief.get_color(1)
 


### PR DESCRIPTION
Implements taking a logo from a static guild logo, fallback to the value specified in config if one doesn't exist.
The cache is currently never invalidated (and lost on bot restart). Looking into making use of http cache-control might be worthwhile if stale guild logos prove to be a problem.

Closes #2 