### PR TITLE
stringify embeds and relay with the original message

### DIFF
--- a/ext/pings/aggregator.py
+++ b/ext/pings/aggregator.py
@@ -46,15 +46,14 @@ class PingAggregator(commands.Cog, name='PingAggregator'):
         for page in paginate:
             embed = self.ping_embed(package, page, paginate)
             embeds.append(embed)
-
         for destination in package['destinations']:
             channel_id = destination['channel_id']
             channel = self.bot.get_channel(channel_id)
 
             if channel:
                 embed = embeds[0]
-                await channel.send(embed=embed, content=destination.get('prefix')
-                )  # Only show prefix on first page.
+                # Only show prefix on first page.
+                await channel.send(embed=embed, content=destination.get('prefix'))
                 for embed in embeds[1:]:
                     await channel.send(embed=embed)
             else:

--- a/ext/pings/discordrelay.py
+++ b/ext/pings/discordrelay.py
@@ -88,6 +88,11 @@ class DiscordRelay(commands.Cog, name='DiscordRelay'):
     async def on_message(self, message):
         if message.mention_everyone:
             message_logo = self.get_message_logo(message)
+            content = message.clean_content
+            for embed in message.embeds:
+                self.logger.debug('Converting embed for message_id={} to string {}'\
+                    .format(message.id, str(embed)))
+                content += '\n\n' + embed.description
             package = {
                 'body': message.clean_content,
                 'sender': message.author.display_name,

--- a/ext/pings/discordrelay.py
+++ b/ext/pings/discordrelay.py
@@ -82,6 +82,30 @@ class DiscordRelay(commands.Cog, name='DiscordRelay'):
                 ','.join(map(lambda x: str(x['channel_id']), destinations)) if len(destinations) > 0 else 'None'))
         return destinations
 
+
+    def stringify_embed(self, embed):
+        content = ''
+        if embed.title:
+            content += 'Title: {}\n'.format(embed.title)
+        if embed.author:
+            content += 'Author: {}\n'.format(embed.author.name)
+        if embed.description:
+            content += 'Description: {}\n'.format(embed.description)
+
+        for field in embed.fields:
+            content += '{}: {}\n'.format(field.name, field.value)
+
+        if embed.footer:
+            content += 'Footer: {}\n'.format(embed.footer.text)
+        if embed.timestamp:
+            content += 'Timestamp: {}\n'.format(embed.timestamp)
+
+        if content == '':
+            return None
+
+        return '====================\n{}===================='.format(content)
+
+
     async def on_ready(self):
         await self.client.change_presence(status=Status.invisible)
 
@@ -92,9 +116,9 @@ class DiscordRelay(commands.Cog, name='DiscordRelay'):
             for embed in message.embeds:
                 self.logger.debug('Converting embed for message_id={} to string {}'\
                     .format(message.id, str(embed)))
-                content += '\n\n' + embed.description
+                content += '\n\n' + self.stringify_embed(embed)
             package = {
-                'body': message.clean_content,
+                'body': content,
                 'sender': message.author.display_name,
                 'destinations': self.route_message(message),
                 'description': '{}: {}'.format(


### PR DESCRIPTION
This PR introduces embed relay functionality. The decision has been made to relay embeds as plaintext by extracting its 'description', rather than relaying the whole thing uniformly. This is because Discord API only allows one embed per message - to maintain 1 to 1 relationship between relayed messages the content must be embedded within the original embed.

Closes #3.